### PR TITLE
Fix PhaseBanner and PhaseBadge styles

### DIFF
--- a/src/PhaseBadge/__tests__/PhaseBadge.test.js
+++ b/src/PhaseBadge/__tests__/PhaseBadge.test.js
@@ -9,14 +9,14 @@ configure({ adapter: new Adapter() })
 describe('<PhaseBadge />', () => {
   describe('when phase == "alpha"', () => {
     it('renders an alpha message', () => {
-      let wrapper = shallow(<PhaseBadge phase="alpha" />)
+      let wrapper = shallow(<PhaseBadge phase="alpha" />).dive()
       expect(wrapper.text()).toMatch(/ALPHA/)
     })
   })
 
   describe('when phase == "beta"', () => {
     it('renders an beta message', () => {
-      let wrapper = shallow(<PhaseBadge phase="beta" />)
+      let wrapper = shallow(<PhaseBadge phase="beta" />).dive()
       expect(wrapper.text()).toMatch(/BETA/)
     })
   })

--- a/src/PhaseBadge/index.js
+++ b/src/PhaseBadge/index.js
@@ -1,30 +1,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { css } from 'react-emotion'
+import styled from 'react-emotion'
 
-const badge = css`
+const Badge = styled.span`
   line-height: 1.8;
   color: #fff;
-  padding: 2px 1rem;
-  margin-right: 1rem;
-  border-radius: 2px;
-  position: relative;
-  display: inline-block;
-  bottom: 2px;
+  padding: 0.45em 1em;
+  border-radius: 0.2em;
+  background-color: ${props =>
+    props.phase === 'alpha' ? '#e8026e' : '#ff5a02'};
 `
-
-const alpha = css`
-  background-color: rgb(232, 2, 110);
-`
-
-const beta = css`
-  background-color: #ff5a02;
-`
-
-export const PhaseBadge = ({ phase }) => (
-  <div className={`${badge} ${phase === 'alpha' ? alpha : beta}`}>
+export const PhaseBadge = ({ phase, ...rest }) => (
+  <Badge {...rest} phase={phase}>
     {phase.toUpperCase()}
-  </div>
+  </Badge>
 )
 
 PhaseBadge.propTypes = {

--- a/src/PhaseBanner/__tests__/PhaseBanner.test.js
+++ b/src/PhaseBanner/__tests__/PhaseBanner.test.js
@@ -1,6 +1,7 @@
 import 'raf/polyfill'
 import React from 'react'
 import { sheet, flush } from 'emotion'
+import styled from 'react-emotion'
 import { shallow, mount, configure } from 'enzyme'
 import { PhaseBanner } from '../../PhaseBanner'
 import Adapter from 'enzyme-adapter-react-16'
@@ -19,13 +20,13 @@ describe('<PhaseBanner />', () => {
     })
   })
 
-  describe('when passed the padding prop', () => {
-    it('uses the padding', () => {
-      let wrapper = mount(
-        <PhaseBanner alpha padding="100vw">
-          under development
-        </PhaseBanner>
-      )
+  describe('when wrapped with the styled function', () => {
+    beforeEach(() => flush())
+    it('picks up the passed styles', () => {
+      let Foo = styled(PhaseBanner)`
+        padding: 100vw;
+      `
+      mount(<Foo alpha>under development</Foo>)
       expect(stringify(sheet)).toMatch(/padding:100vw/)
     })
   })

--- a/src/PhaseBanner/index.js
+++ b/src/PhaseBanner/index.js
@@ -23,11 +23,12 @@ const mediaQuery = Object.keys(breakpoints).reduce((accumulator, label) => {
 const Banner = styled.aside`
   display: flex;
   display: -ms-flexbox;
-  align-items: baseline;
+  align-items: center;
+  -ms-flex-align: center;
+  padding: 0.6rem 4.5rem 0.5rem 4.5rem;
   min-width: 20em;
   background-color: #000;
   color: #fff;
-  padding: ${props => props.padding};
   font: 0.694rem sans-serif;
   ${mediaQuery.small(css`
     display: block;
@@ -38,11 +39,12 @@ const Banner = styled.aside`
 `
 
 const message = css`
-  bottom: 2px;
-  font-weight: 600;
+  margin-left: 1rem;
+  font-weight: bold;
   ${mediaQuery.small(css`
-    display: block;
-    padding: 0.2em;
+    margin-left: 0;
+    display: flex;
+    padding-top: 0.4em;
     font-weight: 400;
   `)};
 `
@@ -56,12 +58,12 @@ const alphaBetaCheck = (props, propName, componentName) => {
 }
 
 export const PhaseBanner = ({
-  padding = '12px 4.5rem 0.5rem 4.5rem',
   alpha = false,
   beta = false,
   children,
+  ...rest
 }) => (
-  <Banner padding={padding}>
+  <Banner {...rest}>
     {alpha && <PhaseBadge phase="alpha" />}
     {beta && <PhaseBadge phase="beta" />}
     <span className={message}>{children}</span>

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -1,5 +1,4 @@
 import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import WordMark from '../WordMark'


### PR DESCRIPTION
These components needed a little polish and a better approach to
allowing people to make modifications to them.

Now you can override their styles with Emotions `styled` function:

```javascript
  let Foo = styled(PhaseBanner)`
    padding: 100vw;
  `
```

This will apply your padding values instead of the defaults supplied by
the component.