### PR TITLE
Release only tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - persist_to_workspace:
           root: ~/repo
           paths: .
-  deploy:
+  release:
     <<: *defaults
     steps:
       - attach_workspace:
@@ -44,18 +44,17 @@ jobs:
             
 workflows:
   version: 2
-  test-deploy:
+  test-and-release:
     jobs:
       - test:
           filters:
             tags:
               only: /^v.*/
-      - deploy:
+      - release:
           requires:
             - test
           filters:
             tags:
               only: /^v.*/
             branches:
-              only:
-                - master
+              ignore: /.*/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint src/**",
     "build":
       "babel --ignore node_modules,__tests__,stories --copy-files --out-dir dist/ src/",
-    "prepublishOnly": "npm build",
+    "prepublishOnly": "npm run build",
     "publish": "npm publish"
   },
   "repository": {


### PR DESCRIPTION
It turns out that CircleCI 2.0 treats it's filters as a logical or,
meaning that the attempt to restrict the deploy/release job from being
run on branches other than master actually left it running (and failing)
whenever code was merged into master. 🤦

https://discuss.circleci.com/t/circle-2-0-workflow-filters-should-be-logical-and-not-or/18231