### PR TITLE
Replace prepublishOnly with prepare and use prod env

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "lint": "eslint src/**",
     "build":
-      "babel --ignore node_modules,__tests__,stories --copy-files --out-dir dist/ src/",
-    "prepublishOnly": "npm run build",
+      "NODE_ENV=production BABEL_ENV=production babel --ignore node_modules,__tests__,stories --copy-files --out-dir dist/ src/",
+    "prepare": "npm run build",
     "publish": "npm publish"
   },
   "repository": {


### PR DESCRIPTION
This commit switches from prepublishOnly to prepare because of an
ongoing issue where npm ends up trying to publish the package twice.
Following the advice in this comment:
https://github.com/npm/npm/issues/15454#issuecomment-288606051

Additionally, the NODE_ENV and BABEL_ENV variables have been set to
production.