### PR TITLE
Refactor test setup into setupTests.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.3",
     "eslint": "^4.19.1",
     "eslint-config-prettier": "^2.9.0",
@@ -58,7 +59,6 @@
   },
   "dependencies": {
     "emotion": "^9.1.3",
-    "enzyme-adapter-react-16": "^1.1.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "react-emotion": "^9.1.3"
@@ -71,6 +71,7 @@
   },
   "jest": {
     "verbose": true,
-    "snapshotSerializers": ["jest-glamor-react"]
+    "snapshotSerializers": ["jest-glamor-react"],
+    "setupTestFrameworkScriptFile": "<rootDir>/setupTests.js"
   }
 }

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,5 @@
+import 'raf/polyfill'
+import { configure } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+
+configure({ adapter: new Adapter() })

--- a/src/Button/__tests__/Button.test.js
+++ b/src/Button/__tests__/Button.test.js
@@ -1,29 +1,25 @@
-import "raf/polyfill"
-import React from "react"
-import { shallow, configure } from "enzyme"
-import { sheet, flush } from "emotion"
-import Button from "../../Button"
-import Adapter from "enzyme-adapter-react-16"
-
-configure({ adapter: new Adapter() })
+import React from 'react'
+import { shallow } from 'enzyme'
+import { sheet, flush } from 'emotion'
+import Button from '../../Button'
 
 const stringify = stylesheet =>
-  stylesheet.tags.map(tag => tag.textContent || "").join("")
+  stylesheet.tags.map(tag => tag.textContent || '').join('')
 
-describe("<Button />", () => {
+describe('<Button />', () => {
   afterEach(() => flush())
 
-  it("can be rendered", () => {
+  it('can be rendered', () => {
     let wrapper = shallow(<Button />).dive()
-    expect(wrapper.is("button")).toBeTruthy()
+    expect(wrapper.is('button')).toBeTruthy()
   })
 
-  it("has a default background color", () => {
+  it('has a default background color', () => {
     shallow(<Button>submit</Button>).dive()
     expect(stringify(sheet)).toMatch(/background-color:#eaebed/)
   })
 
-  it("<Button primary /> has a different background-color", () => {
+  it('<Button primary /> has a different background-color', () => {
     shallow(<Button primary>submit</Button>).dive()
     expect(stringify(sheet)).toMatch(/background-color:#335075/)
   })

--- a/src/DownwardChevron/__tests__/DownwardChevron.test.js
+++ b/src/DownwardChevron/__tests__/DownwardChevron.test.js
@@ -1,45 +1,41 @@
-import "raf/polyfill"
-import React from "react"
-import { sheet, flush } from "emotion"
-import { mount, shallow, configure } from "enzyme"
-import DownwardChevron from "../../DownwardChevron"
-import Adapter from "enzyme-adapter-react-16"
-
-configure({ adapter: new Adapter() })
+import React from 'react'
+import { sheet, flush } from 'emotion'
+import { mount, shallow } from 'enzyme'
+import DownwardChevron from '../../DownwardChevron'
 
 const stringify = stylesheet =>
-  stylesheet.tags.map(tag => tag.textContent || "").join("")
+  stylesheet.tags.map(tag => tag.textContent || '').join('')
 
-describe("<DownwardChevron />", () => {
+describe('<DownwardChevron />', () => {
   afterEach(() => flush())
 
-  it("can be rendered", () => {
+  it('can be rendered', () => {
     let wrapper = shallow(<DownwardChevron />).dive()
-    expect(wrapper.is("span")).toBeTruthy()
+    expect(wrapper.is('span')).toBeTruthy()
   })
 
-  it("accepts a width prop", () => {
-    let wrapper = shallow(<DownwardChevron width="1000%" />).find("svg")
-    expect(wrapper.props().width).toEqual("1000%")
+  it('accepts a width prop', () => {
+    let wrapper = shallow(<DownwardChevron width="1000%" />).find('svg')
+    expect(wrapper.props().width).toEqual('1000%')
   })
 
-  it("defaults to width of 0.7em", () => {
-    let wrapper = shallow(<DownwardChevron />).find("svg")
-    expect(wrapper.props().width).toEqual("0.7em")
+  it('defaults to width of 0.7em', () => {
+    let wrapper = shallow(<DownwardChevron />).find('svg')
+    expect(wrapper.props().width).toEqual('0.7em')
   })
 
-  it("accepts a colour", () => {
+  it('accepts a colour', () => {
     let wrapper = shallow(<DownwardChevron colour="#abc" />)
-    let path = wrapper.find("path")
-    expect(path.props().style.fill).toEqual("#abc")
+    let path = wrapper.find('path')
+    expect(path.props().style.fill).toEqual('#abc')
   })
 
-  it("allows the padding around the chevron to be set", () => {
+  it('allows the padding around the chevron to be set', () => {
     mount(<DownwardChevron verticalPadding="10vh" horizontalPadding="4em" />)
     expect(stringify(sheet)).toMatch(/padding:10vh 4em/)
   })
 
-  it("the padding has default values of 0.3em", () => {
+  it('the padding has default values of 0.3em', () => {
     mount(<DownwardChevron />)
     expect(stringify(sheet)).toMatch(/padding:0.3em 0.3em/)
   })

--- a/src/EnerguideLogo/__tests__/EnerguideLogo.test.js
+++ b/src/EnerguideLogo/__tests__/EnerguideLogo.test.js
@@ -1,24 +1,20 @@
-import "raf/polyfill"
-import React from "react"
-import { shallow, configure } from "enzyme"
-import EnerguideLogo from "../../EnerguideLogo"
-import Adapter from "enzyme-adapter-react-16"
+import React from 'react'
+import { shallow } from 'enzyme'
+import EnerguideLogo from '../../EnerguideLogo'
 
-configure({ adapter: new Adapter() })
-
-describe("<EnerguideLogo />", () => {
-  it("renders svg", () => {
+describe('<EnerguideLogo />', () => {
+  it('renders svg', () => {
     let wrapper = shallow(<EnerguideLogo />)
-    expect(wrapper.is("svg")).toBeTruthy()
+    expect(wrapper.is('svg')).toBeTruthy()
   })
 
-  it("accepts a width prop", () => {
+  it('accepts a width prop', () => {
     let wrapper = shallow(<EnerguideLogo width="1000%" />)
-    expect(wrapper.props().width).toEqual("1000%")
+    expect(wrapper.props().width).toEqual('1000%')
   })
 
-  it("defaults to width of 10em", () => {
+  it('defaults to width of 10em', () => {
     let wrapper = shallow(<EnerguideLogo />)
-    expect(wrapper.props().width).toEqual("15em")
+    expect(wrapper.props().width).toEqual('15em')
   })
 })

--- a/src/GoCSignature/__tests__/GoCSignature.test.js
+++ b/src/GoCSignature/__tests__/GoCSignature.test.js
@@ -1,68 +1,64 @@
-import "raf/polyfill"
-import React from "react"
-import { sheet, flush } from "emotion"
-import { mount, shallow, configure } from "enzyme"
-import GoCSignature from "../../GoCSignature"
-import Adapter from "enzyme-adapter-react-16"
-
-configure({ adapter: new Adapter() })
+import React from 'react'
+import { sheet, flush } from 'emotion'
+import { mount, shallow } from 'enzyme'
+import GoCSignature from '../../GoCSignature'
 
 const stringify = stylesheet =>
-  stylesheet.tags.map(tag => tag.textContent || "").join("")
+  stylesheet.tags.map(tag => tag.textContent || '').join('')
 
-describe("<GoCSignature />", () => {
+describe('<GoCSignature />', () => {
   afterEach(() => flush())
 
-  it("renders svg", () => {
+  it('renders svg', () => {
     let wrapper = shallow(<GoCSignature />)
-    expect(wrapper.is("svg")).toBeTruthy()
+    expect(wrapper.is('svg')).toBeTruthy()
   })
 
-  it("accepts a width prop", () => {
+  it('accepts a width prop', () => {
     let wrapper = shallow(<GoCSignature width="1000%" />)
-    expect(wrapper.props().width).toEqual("1000%")
+    expect(wrapper.props().width).toEqual('1000%')
   })
 
-  it("defaults to width of 10em", () => {
+  it('defaults to width of 10em', () => {
     let wrapper = shallow(<GoCSignature />)
-    expect(wrapper.props().width).toEqual("10em")
+    expect(wrapper.props().width).toEqual('10em')
   })
 
-  it("the color passed to the flag prop ends up in the generated stylesheet", () => {
+  it('the color passed to the flag prop ends up in the generated stylesheet', () => {
     // eslint-disable-next-line no-unused-vars
     let wrapper = mount(<GoCSignature flag="papayawhip" />)
     expect(stringify(sheet)).toMatch(/fill:papayawhip/)
   })
 
-  it("the flag defaults to #F00", () => {
+  it('the flag defaults to #F00', () => {
     let wrapper = mount(<GoCSignature />)
-    let flag = wrapper.find("Styled(path)").first()
-    expect(flag.props().flag).toEqual("#F00")
+    let flag = wrapper.find('Styled(path)').first()
+    expect(flag.props().flag).toEqual('#F00')
   })
 
-  it("the text defaults to #000", () => {
+  it('the text defaults to #000', () => {
     let wrapper = mount(<GoCSignature />)
-    let text = wrapper.find("Styled(path)").last()
-    expect(text.props().text).toEqual("#000")
+    let text = wrapper.find('Styled(path)').last()
+    expect(text.props().text).toEqual('#000')
   })
 
-  it("the color passed to the text prop ends up in the generated stylesheet", () => {
+  it('the color passed to the text prop ends up in the generated stylesheet', () => {
     // eslint-disable-next-line no-unused-vars
     let wrapper = mount(<GoCSignature text="mistyrose" />)
     expect(stringify(sheet)).toMatch(/fill:mistyrose/)
   })
 
-  it("outputs english text first by default", () => {
+  it('outputs english text first by default', () => {
     let wrapper = mount(<GoCSignature />)
-      .find("[data-fiptext]")
+      .find('[data-fiptext]')
       .first()
-    expect(wrapper.props().transform).toEqual("translate(0 0)") // no change
+    expect(wrapper.props().transform).toEqual('translate(0 0)') // no change
   })
 
   it("outputs french text first when passed lang='fr'", () => {
     let wrapper = mount(<GoCSignature lang="fr" />)
-      .find("[data-fiptext]")
+      .find('[data-fiptext]')
       .first()
-    expect(wrapper.props().transform).toEqual("translate(317 0)")
+    expect(wrapper.props().transform).toEqual('translate(317 0)')
   })
 })

--- a/src/PhaseBadge/__tests__/PhaseBadge.test.js
+++ b/src/PhaseBadge/__tests__/PhaseBadge.test.js
@@ -1,10 +1,6 @@
-import 'raf/polyfill'
 import React from 'react'
-import { shallow, configure } from 'enzyme'
+import { shallow } from 'enzyme'
 import { PhaseBadge } from '../../PhaseBadge'
-import Adapter from 'enzyme-adapter-react-16'
-
-configure({ adapter: new Adapter() })
 
 describe('<PhaseBadge />', () => {
   describe('when phase == "alpha"', () => {

--- a/src/PhaseBanner/__tests__/PhaseBanner.test.js
+++ b/src/PhaseBanner/__tests__/PhaseBanner.test.js
@@ -1,15 +1,11 @@
-import 'raf/polyfill'
 import React from 'react'
 import { sheet, flush } from 'emotion'
 import styled from 'react-emotion'
-import { shallow, mount, configure } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import { PhaseBanner } from '../../PhaseBanner'
-import Adapter from 'enzyme-adapter-react-16'
 
 const stringify = stylesheet =>
   stylesheet.tags.map(tag => tag.textContent || '').join('')
-
-configure({ adapter: new Adapter() })
 
 describe('<PhaseBanner />', () => {
   describe('when passed the alpha prop', () => {

--- a/src/UpwardChevron/__tests__/UpwardChevron.test.js
+++ b/src/UpwardChevron/__tests__/UpwardChevron.test.js
@@ -1,45 +1,41 @@
-import "raf/polyfill"
-import React from "react"
-import { mount, shallow, configure } from "enzyme"
-import { sheet, flush } from "emotion"
-import UpwardChevron from "../../UpwardChevron"
-import Adapter from "enzyme-adapter-react-16"
-
-configure({ adapter: new Adapter() })
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import { sheet, flush } from 'emotion'
+import UpwardChevron from '../../UpwardChevron'
 
 const stringify = stylesheet =>
-  stylesheet.tags.map(tag => tag.textContent || "").join("")
+  stylesheet.tags.map(tag => tag.textContent || '').join('')
 
-describe("<UpwardChevron />", () => {
+describe('<UpwardChevron />', () => {
   afterEach(() => flush())
 
-  it("can be rendered", () => {
+  it('can be rendered', () => {
     let wrapper = shallow(<UpwardChevron />).dive()
-    expect(wrapper.is("span")).toBeTruthy()
+    expect(wrapper.is('span')).toBeTruthy()
   })
 
-  it("accepts a width prop", () => {
-    let wrapper = shallow(<UpwardChevron width="1000%" />).find("svg")
-    expect(wrapper.props().width).toEqual("1000%")
+  it('accepts a width prop', () => {
+    let wrapper = shallow(<UpwardChevron width="1000%" />).find('svg')
+    expect(wrapper.props().width).toEqual('1000%')
   })
 
-  it("defaults to width of 0.7em", () => {
-    let wrapper = shallow(<UpwardChevron />).find("svg")
-    expect(wrapper.props().width).toEqual("0.7em")
+  it('defaults to width of 0.7em', () => {
+    let wrapper = shallow(<UpwardChevron />).find('svg')
+    expect(wrapper.props().width).toEqual('0.7em')
   })
 
-  it("accepts a colour", () => {
+  it('accepts a colour', () => {
     let wrapper = shallow(<UpwardChevron colour="#abc" />)
-    let path = wrapper.find("path")
-    expect(path.props().style.fill).toEqual("#abc")
+    let path = wrapper.find('path')
+    expect(path.props().style.fill).toEqual('#abc')
   })
 
-  it("allows the padding around the chevron to be set", () => {
+  it('allows the padding around the chevron to be set', () => {
     mount(<UpwardChevron verticalPadding="10vh" horizontalPadding="4em" />)
     expect(stringify(sheet)).toMatch(/padding:10vh 4em/)
   })
 
-  it("the padding has default values of 0.3em", () => {
+  it('the padding has default values of 0.3em', () => {
     shallow(<UpwardChevron />).dive()
     expect(stringify(sheet)).toMatch(/padding:0.3em 0.3em/)
   })

--- a/src/WordMark/__tests__/WordMark.test.js
+++ b/src/WordMark/__tests__/WordMark.test.js
@@ -1,39 +1,35 @@
-import "raf/polyfill"
-import React from "react"
-import { mount, shallow, configure } from "enzyme"
-import { sheet, flush } from "emotion"
-import WordMark from "../../WordMark"
-import Adapter from "enzyme-adapter-react-16"
-
-configure({ adapter: new Adapter() })
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import { sheet, flush } from 'emotion'
+import WordMark from '../../WordMark'
 
 const stringify = stylesheet =>
-  stylesheet.tags.map(tag => tag.textContent || "").join("")
+  stylesheet.tags.map(tag => tag.textContent || '').join('')
 
-describe("<WordMark />", () => {
+describe('<WordMark />', () => {
   afterEach(() => flush())
 
-  it("renders svg", () => {
+  it('renders svg', () => {
     let wrapper = shallow(<WordMark />)
-    expect(wrapper.is("svg")).toBeTruthy()
+    expect(wrapper.is('svg')).toBeTruthy()
   })
 
-  it("accepts a width prop", () => {
+  it('accepts a width prop', () => {
     let wrapper = shallow(<WordMark width="1000%" />)
-    expect(wrapper.props().width).toEqual("1000%")
+    expect(wrapper.props().width).toEqual('1000%')
   })
 
-  it("defaults to width of 10em", () => {
+  it('defaults to width of 10em', () => {
     let wrapper = shallow(<WordMark />)
-    expect(wrapper.props().width).toEqual("10em")
+    expect(wrapper.props().width).toEqual('10em')
   })
 
-  it("allows the flag colour to be set", () => {
+  it('allows the flag colour to be set', () => {
     mount(<WordMark flag="#fff" />)
     expect(stringify(sheet)).toMatch(/fill:#fff/)
   })
 
-  it("allows the text colour to be set", () => {
+  it('allows the text colour to be set', () => {
     mount(<WordMark text="#ddd" />)
     expect(stringify(sheet)).toMatch(/fill:#ddd/)
   })


### PR DESCRIPTION
This slims down the tests by making use of Jest's
setuptestframeworkscriptfile option.