### PR TITLE
Allow arbitrary props to be passed through to svgs

### DIFF
--- a/src/EnerguideLogo/EnerguideLogo.js
+++ b/src/EnerguideLogo/EnerguideLogo.js
@@ -1,6 +1,6 @@
-import React from "react"
-import styled from "react-emotion"
-import PropTypes from "prop-types"
+import React from 'react'
+import styled from 'react-emotion'
+import PropTypes from 'prop-types'
 
 const Rect = styled.rect`
   fill: #000;
@@ -10,7 +10,7 @@ const LogoText = styled.path`
   fill: #fff;
 `
 
-const EnerguideLogo = ({ width = "15em" }) => (
+const EnerguideLogo = ({ width = '15em', ...props }) => (
   <svg
     role="img"
     aria-label="Energuide"
@@ -19,6 +19,7 @@ const EnerguideLogo = ({ width = "15em" }) => (
     viewBox="0 0 176.06615 50.069547"
     width={width}
     preserveAspectRatio="xMinYMin"
+    {...props}
   >
     <title>Energuide</title>
     <desc>Energuide Logo</desc>

--- a/src/EnerguideLogo/__tests__/EnerguideLogo.test.js
+++ b/src/EnerguideLogo/__tests__/EnerguideLogo.test.js
@@ -17,4 +17,10 @@ describe('<EnerguideLogo />', () => {
     let wrapper = shallow(<EnerguideLogo />)
     expect(wrapper.props().width).toEqual('15em')
   })
+
+  it('allows passing through abritrary props', () => {
+    let wrapper = shallow(<EnerguideLogo focusable="false" whizz="bang" />)
+    expect(wrapper.props().focusable).toEqual('false')
+    expect(wrapper.props().whizz).toEqual('bang')
+  })
 })

--- a/src/GoCSignature/GoCSignature.js
+++ b/src/GoCSignature/GoCSignature.js
@@ -16,6 +16,7 @@ const Wordmark = ({
   flag = '#F00',
   text = '#000',
   lang = 'en',
+  ...props
 }) => (
   <svg
     role="img"
@@ -28,6 +29,7 @@ const Wordmark = ({
     viewBox="0 0 819 75.97"
     preserveAspectRatio="xMinYMin meet"
     shapeRendering="geometricPrecision"
+    {...props}
   >
     <g id="sig" transform="translate(0 -0.02)">
       <FipFlag

--- a/src/GoCSignature/__tests__/GoCSignature.test.js
+++ b/src/GoCSignature/__tests__/GoCSignature.test.js
@@ -61,4 +61,10 @@ describe('<GoCSignature />', () => {
       .first()
     expect(wrapper.props().transform).toEqual('translate(317 0)')
   })
+
+  it('allows passing through abritrary props', () => {
+    let wrapper = shallow(<GoCSignature focusable="false" whizz="bang" />)
+    expect(wrapper.props().focusable).toEqual('false')
+    expect(wrapper.props().whizz).toEqual('bang')
+  })
 })

--- a/src/WordMark/WordMark.js
+++ b/src/WordMark/WordMark.js
@@ -15,6 +15,7 @@ const Wordmark = ({
   flag = '#F00',
   text = '#000',
   lang = 'en',
+  ...props
 }) => (
   <svg
     role="img"
@@ -29,6 +30,7 @@ const Wordmark = ({
     height="100%"
     viewBox="0 0 143 34"
     preserveAspectRatio="xMinYMin meet"
+    {...props}
   >
     <g id="wmms" transform="translate(-1, -1)">
       <FipFlag

--- a/src/WordMark/__tests__/WordMark.test.js
+++ b/src/WordMark/__tests__/WordMark.test.js
@@ -33,4 +33,10 @@ describe('<WordMark />', () => {
     mount(<WordMark text="#ddd" />)
     expect(stringify(sheet)).toMatch(/fill:#ddd/)
   })
+
+  it('allows passing through abritrary props', () => {
+    let wrapper = shallow(<WordMark focusable="false" whizz="bang" />)
+    expect(wrapper.props().focusable).toEqual('false')
+    expect(wrapper.props().whizz).toEqual('bang')
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2348,7 +2348,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.3:
+core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.3, core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 


### PR DESCRIPTION
We ran into a weird problem where IE11 will include svgs in keyboard focus unless it has a `focusable="false"` attribute. Adding a `tabindex="-1"` doesn't affect it.

Since we may have other requirements in the future, I've added a general way to pass `props` to svgs.

Source:
https://github.com/PolymerElements/iron-iconset-svg/issues/46